### PR TITLE
Fixed inconsistent indent in file

### DIFF
--- a/templates/configure-dockbarx-launcher.sh.j2
+++ b/templates/configure-dockbarx-launcher.sh.j2
@@ -26,8 +26,8 @@ echo ''
 
 if [[ "$new_launchers" == "$existing_launchers" ]]
 then
-  echo 'No changes.' 1>&2
-  exit 1
+    echo 'No changes.' 1>&2
+    exit 1
 fi
 
 echo "New list of applications: $new_launchers"


### PR DESCRIPTION
A couple of lines in `configure-dockbax-launcher.sh.j2` had the an indent of 2 spaces where the rest of the file uses 4.