### PR TITLE
Renamed handler to make it unique to this role

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: compile glib schemas
+- name: compile glib schemas pin_to_launcher
   become: yes
   command: '/usr/bin/glib-compile-schemas {{ pin_to_launcher_glib_schemas_directory }}'

--- a/tasks/unity.yml
+++ b/tasks/unity.yml
@@ -14,4 +14,4 @@
     group: root
     mode: 'u=rw,go=r'
   notify:
-    - compile glib schemas
+    - compile glib schemas pin_to_launcher


### PR DESCRIPTION
Since the handler is specific to properties of this role the name needs to be unique to this role.