### PR TITLE
Moved launcher filtering into custom filter

### DIFF
--- a/filter_plugins/launcher_filter.py
+++ b/filter_plugins/launcher_filter.py
@@ -1,0 +1,64 @@
+import re
+
+from jinja2.filters import contextfilter
+
+
+@contextfilter
+def to_dockbarx_items(context, pin_to_launcher_favorites):
+    '''
+    returns the DockbarX launcher items
+    '''
+
+    pin_to_launcher_favorites = list(pin_to_launcher_favorites)
+
+    omit = context.resolve('omit')
+
+    launcher_items = []
+
+    for favourite in pin_to_launcher_favorites:
+        application = favourite.get('application')
+        if application not in ('', None, omit):
+            when_desktop = favourite.get('when_desktop')
+            if when_desktop in ('dockbarx', None):
+                application_id = favourite.get('application_id')
+                if application_id is None:
+                    application_id = re.sub('(.*)\\.desktop$', '\\1', application)
+                launcher_items.append(application_id + ';/usr/share/applications/' + application)
+
+    return launcher_items
+
+
+@contextfilter
+def to_unity_items(context, pin_to_launcher_favorites):
+    '''
+    returns the Unity launcher items
+    '''
+
+    pin_to_launcher_favorites = list(pin_to_launcher_favorites)
+
+    omit = context.resolve('omit')
+
+    launcher_items = []
+
+    for favourite in pin_to_launcher_favorites:
+        application = favourite.get('application')
+        if application not in ('', None, omit):
+            when_desktop = favourite.get('when_desktop')
+            if when_desktop in ('unity', None):
+                launcher_items.append("'application://" + application + "'")
+
+        unity = favourite.get('unity')
+        if unity not in ('', None, omit):
+            launcher_items.append("'unity://" + unity + "'")
+
+    return launcher_items
+
+
+class FilterModule(object):
+    ''' Launcher filter '''
+
+    def filters(self):
+        return {
+            'to_dockbarx_items': to_dockbarx_items,
+            'to_unity_items': to_unity_items
+        }

--- a/templates/configure-dockbarx-launcher.sh.j2
+++ b/templates/configure-dockbarx-launcher.sh.j2
@@ -2,19 +2,7 @@
 
 # {{ ansible_managed }}
 
-{% set first_app = True %}
-{# Using comments to suppress whitespace #}
-new_launchers="[{#
-#}{% for favourite in pin_to_launcher_favorites %}{#
-    #}{% if favourite.application is defined and favourite.application not in ('', None, omit) %}{#
-        #}{% if not favourite.when_desktop is defined or favourite.when_desktop == 'dockbarx' %}{#
-            #}{% if not first_app %},{% endif %}{% set first_app = False %}{#
-            #}{% set default_application_id = favourite.application | regex_replace('(.*)\\.desktop$', '\\1') %}{#
-            #}{{ favourite.application_id | default(default_application_id) }}{#
-            #};/usr/share/applications/{{ favourite.application }}{#
-        #}{% endif %}{#
-    #}{% endif %}{#
-#}{% endfor %}]"
+new_launchers="[{{ pin_to_launcher_favorites | to_dockbarx_items | join(',') }}]"
 
 # Get the current list of pinned applications
 existing_launchers=$(gconftool-2 --direct \

--- a/templates/launcher.gschema.override.j2
+++ b/templates/launcher.gschema.override.j2
@@ -2,20 +2,4 @@
 
 {% set first_fav = True %}
 [com.canonical.Unity.Launcher]
-{# Using comments to suppress whitespace #}
-favorites = [{#
-#}{% for favourite in pin_to_launcher_favorites %}{#
-
-    #}{% if favourite.application is defined and favourite.application not in ('', None, omit) %}{#
-        #}{% if not favourite.when_desktop is defined or favourite.when_desktop == 'unity' %}{#
-            #}{% if not first_fav %}, {% endif %}{% set first_fav = False %}{#
-            #}'application://{{ favourite.application }}'{#
-        #}{% endif %}{#
-    #}{% endif %}{#
-
-    #}{% if favourite.unity is defined and favourite.unity not in ('', None, omit) %}{#
-        #}{% if not first_fav %}, {% endif %}{% set first_fav = False %}{#
-        #}'unity://{{ favourite.unity }}'{#
-    #}{% endif %}{#
-
-#}{% endfor %}]
+favorites = [{{ pin_to_launcher_favorites | to_unity_items | join(', ') }}]


### PR DESCRIPTION
Molecule 1.24 updated Jinja2 to 2.9.6, which no longer allows you to update a variable inside a loop; this broke the comma separated values in the templates.

It's cleaner having the filtering in a custom filter anyway.