### PR TITLE
Raised minimum Ansible version to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Role to pin applications to the desktop application launcher.
 Requirements
 ------------
 
-* Ansible >= 1.9
+* Ansible >= 2.0
 
 * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Role for pinning applications to the desktop application launcher.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 1.9
+  min_ansible_version: 2.0
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
Since the implementation has changed to use custom filters, and there's no easy way to test this on Ansible 1.9, the minimum Ansible version is now raised to 2.0.