### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/tasks/dockbarx.yml
+++ b/tasks/dockbarx.yml
@@ -8,7 +8,7 @@
 - name: create tmp dir
   become: yes
   file:
-    path: "{{ pin_to_launcher_tmp_dir }}"
+    path: '{{ pin_to_launcher_tmp_dir }}'
     state: directory
     owner: root
     group: root
@@ -18,14 +18,14 @@
   become: yes
   template:
     src: configure-dockbarx-launcher.sh.j2
-    dest: "{{ pin_to_launcher_dockbarx_configuration_script }}"
+    dest: '{{ pin_to_launcher_dockbarx_configuration_script }}'
     owner: root
     group: root
     mode: 'u=rwx,go='
 
 - name: apply dockbarx configuration
   become: yes
-  command: "{{ pin_to_launcher_dockbarx_configuration_script }}"
+  command: '{{ pin_to_launcher_dockbarx_configuration_script }}'
   register: dockbarx_result
   changed_when: 'dockbarx_result.rc == 0'
   failed_when: 'dockbarx_result.rc >= 2'

--- a/tasks/unity.yml
+++ b/tasks/unity.yml
@@ -9,7 +9,7 @@
   become: yes
   template:
     src: launcher.gschema.override.j2
-    dest: "{{ pin_to_launcher_glib_schemas_directory }}/20_ansible_launcher.gschema.override"
+    dest: '{{ pin_to_launcher_glib_schemas_directory }}/20_ansible_launcher.gschema.override'
     owner: root
     group: root
     mode: 'u=rw,go=r'
@@ -22,5 +22,5 @@
     # doesn't make sense to use a handler, which are global to the playbook.
     - skip_ansible_lint
   become: yes
-  command: "/usr/bin/glib-compile-schemas {{ pin_to_launcher_glib_schemas_directory }}"
+  command: '/usr/bin/glib-compile-schemas {{ pin_to_launcher_glib_schemas_directory }}'
   when: launcher_config.changed

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -22,8 +22,8 @@
         - application: test-app3.desktop
           when_desktop: unity
         - application: ''
-        - application: "{{ None }}"
-        - application: "{{ omit }}"
+        - application: '{{ None }}'
+        - application: '{{ omit }}'
         - {}
     - role: ansible-role-pin-to-launcher
       pin_to_launcher: unity
@@ -34,10 +34,10 @@
         - application: test-app5.desktop
           when_desktop: dockbarx
         - application: ''
-        - application: "{{ None }}"
-        - application: "{{ omit }}"
+        - application: '{{ None }}'
+        - application: '{{ omit }}'
         - unity: running-apps
         - unity: ''
-        - unity: "{{ None }}"
-        - unity: "{{ omit }}"
+        - unity: '{{ None }}'
+        - unity: '{{ omit }}'
         - {}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 pin_to_launcher_tmp_dir: "{{ ansible_env.HOME + '/.ansible/tmp' }}"
 
 # Location of script for configuring DockbarX
-pin_to_launcher_dockbarx_configuration_script: "{{ pin_to_launcher_tmp_dir }}/configure-dockbarx-launcher.sh"
+pin_to_launcher_dockbarx_configuration_script: '{{ pin_to_launcher_tmp_dir }}/configure-dockbarx-launcher.sh'
 
 # Directory where GLib schemas are located
 pin_to_launcher_glib_schemas_directory: /usr/share/glib-2.0/schemas


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.