### PR TITLE
Dropped documented support for Ubuntu Wily

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requirements
 
 * Ubuntu
 
-    * Wily (15.10)
+    * Xenial (16.04)
     * Note: other Ubuntu versions are likely to work but have not been tested.
 
 * A supported launcher

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - wily
+        - xenial
   galaxy_tags:
     - dockbar
     - dockbarx


### PR DESCRIPTION
It's no longer a supported Ubuntu version.