### PR TITLE
Updated docs on Unity's Ubuntu status

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requirements
 
     * [Unity](https://en.wikipedia.org/wiki/Unity_(user_interface))
 
-        * The default desktop installed with Ubuntu.
+        * The default desktop installed with Ubuntu prior to Bionic (18.04).
 
     * [DockbarX](https://github.com/M7S/dockbarx)
 


### PR DESCRIPTION
It's no longer the default desktop.