### PR TITLE
Increased minimum Ansible version to 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 matrix:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.5.10
+        - MOLECULEW_ANSIBLE=2.6.18
         - MOLECULE_SCENARIO=default
       python: '2.7'
     - env:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Role to pin applications to the desktop application launcher.
 Requirements
 ------------
 
-* Ansible >= 2.5
+* Ansible >= 2.6
 
 * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for pinning applications to the desktop application launcher.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.5
+  min_ansible_version: 2.6
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.6.