### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Requirements
 
 * Ubuntu
 
-    * Xenial (16.04)
     * Bionic (18.04)
     * Focal (20.04)
     * Note: other Ubuntu versions are likely to work but have not been tested.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
   galaxy_tags:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.