### PR TITLE
fix: cannot import name 'contextfilter' from 'jinja2.filters'

### DIFF
--- a/filter_plugins/launcher_filter.py
+++ b/filter_plugins/launcher_filter.py
@@ -1,7 +1,7 @@
-from jinja2.filters import contextfilter
+from jinja2.filters import pass_context
 
 
-@contextfilter
+@pass_context
 def to_gnome_items(context, pin_to_launcher_favorites):
     '''
     returns the Gnome launcher items


### PR DESCRIPTION
Jinja2 `contextfilter` does not exist anymore: https://jinja.palletsprojects.com/en/stable/api/#utilities

It is replaced by `pass_context` 